### PR TITLE
Eval() is a security issue for modern browsers. Fixing dependency on old unmaintained library

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cytoscape": "^3.2.0"
   },
   "dependencies": {
-    "numeric": "1.2.6",
-    "cose-base": "^1.0.0"
+    "cose-base": "^1.0.0",
+    "svd-js": "^1.0.6"
   }
 }

--- a/src/fcose/spectral.js
+++ b/src/fcose/spectral.js
@@ -3,7 +3,7 @@
 */
 
 const aux = require('./auxiliary');
-const numeric = require('numeric');
+const svdjs = require('svd-js');
 
 // main function that spectral layout is processed
 let spectralLayout = function(options){
@@ -167,11 +167,11 @@ let spectralLayout = function(options){
   // perform the SVD algorithm and apply a regularization step
   let sample = function(){
 
-    let SVDResult = numeric.svd(PHI);
+    let SVDResult = svdjs.SVD(PHI);
 
-    let a_w = SVDResult.S;
-    let a_u = SVDResult.U;
-    let a_v = SVDResult.V;        
+    let a_w = SVDResult.q;
+    let a_u = SVDResult.u;
+    let a_v = SVDResult.v;
 
     let max_s = a_w[0]*a_w[0]*a_w[0];
 
@@ -188,9 +188,36 @@ let spectralLayout = function(options){
       }
     }
 
-    INV = aux.multMat(aux.multMat(a_v, a_Sig), numeric.transpose(a_u));
+    INV = aux.multMat(aux.multMat(a_v, a_Sig), transpose(a_u));
 
   };
+
+  function transpose(x) {
+    var i,j,m = x.length,n = x[0].length, ret=Array(n),A0,A1,Bj;
+    for(j=0;j<n;j++) ret[j] = Array(m);
+    for(i=m-1;i>=1;i-=2) {
+      A1 = x[i];
+      A0 = x[i-1];
+      for(j=n-1;j>=1;--j) {
+        Bj = ret[j]; Bj[i] = A1[j]; Bj[i-1] = A0[j];
+        --j;
+        Bj = ret[j]; Bj[i] = A1[j]; Bj[i-1] = A0[j];
+      }
+      if(j===0) {
+        Bj = ret[0]; Bj[i] = A1[0]; Bj[i-1] = A0[0];
+      }
+    }
+    if(i===0) {
+      A0 = x[0];
+      for(j=n-1;j>=1;--j) {
+        ret[j][0] = A0[j];
+        --j;
+        ret[j][0] = A0[j];
+      }
+      if(j===0) { ret[0][0] = A0[0]; }
+    }
+    return ret;
+  }
 
   // calculate final coordinates 
   let powerIteration = function(){


### PR DESCRIPTION
I have fixed dependency on old unmaintained library, which had a security issue when using eval() function.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
The library "numeric" is 8 years without any update and shouldnt be used. 

 * Added different library for computing Singular Value Decomposition (SVD-js still maintained in 2020).
 * Added transform function from numeric library directly, as it is an easy Matrix Transformation.